### PR TITLE
[FEAT] 강아지 삭제 시 관련 정보 삭제 #100

### DIFF
--- a/meongcare/src/main/java/com/meongcare/domain/dog/application/DogService.java
+++ b/meongcare/src/main/java/com/meongcare/domain/dog/application/DogService.java
@@ -1,5 +1,13 @@
 package com.meongcare.domain.dog.application;
 
+import com.meongcare.domain.excreta.domain.repository.ExcretaQueryRepository;
+import com.meongcare.domain.excreta.domain.repository.ExcretaRepository;
+import com.meongcare.domain.feed.domain.repository.FeedQueryRepository;
+import com.meongcare.domain.feed.domain.repository.FeedRecordQueryRepository;
+import com.meongcare.domain.feed.domain.repository.FeedRepository;
+import com.meongcare.domain.feed.domain.repository.vo.GetFeedsVO;
+import com.meongcare.domain.medicalrecord.domain.repository.MedicalRecordQueryRepository;
+import com.meongcare.domain.medicalrecord.domain.repository.MedicalRecordRepository;
 import com.meongcare.domain.member.domain.entity.Member;
 import com.meongcare.domain.member.domain.repository.MemberRepository;
 import com.meongcare.domain.dog.domain.DogRepository;
@@ -9,7 +17,12 @@ import com.meongcare.domain.dog.presentation.dto.request.SaveDogRequest;
 import com.meongcare.domain.dog.presentation.dto.response.GetDogResponse;
 import com.meongcare.domain.dog.presentation.dto.response.GetDogsResponse;
 import com.meongcare.domain.supplements.application.SupplementsService;
+import com.meongcare.domain.supplements.domain.repository.SupplementsQueryRepository;
+import com.meongcare.domain.supplements.domain.repository.SupplementsTimeQueryRepository;
+import com.meongcare.domain.symptom.domain.repository.SymptomQueryRepository;
+import com.meongcare.domain.symptom.domain.repository.SymptomRepository;
 import com.meongcare.domain.weight.domain.entity.Weight;
+import com.meongcare.domain.weight.domain.repository.WeightQueryRepository;
 import com.meongcare.domain.weight.domain.repository.WeightRepository;
 import com.meongcare.infra.image.ImageDirectory;
 import com.meongcare.infra.image.ImageHandler;
@@ -30,7 +43,16 @@ public class DogService {
     private final WeightRepository weightRepository;
     private final ImageHandler imageHandler;
 
-    private final SupplementsService supplementsService;
+    private SymptomQueryRepository symptomQueryRepository;
+    private FeedQueryRepository feedQueryRepository;
+    private MedicalRecordQueryRepository medicalRecordQueryRepository;
+    private ExcretaQueryRepository excretaQueryRepository;
+    private WeightQueryRepository weightQueryRepository;
+    private FeedRecordQueryRepository feedRecordQueryRepository;
+    private SupplementsQueryRepository supplementsQueryRepository;
+    private SupplementsTimeQueryRepository supplementsTimeQueryRepository;
+    private SupplementsService supplementsService;
+
 
     @Transactional
     public void saveDog(MultipartFile multipartFile, SaveDogRequest saveDogRequest, Long userId) {
@@ -66,7 +88,19 @@ public class DogService {
     @Transactional
     public void deleteDog(Long dogId) {
         Dog dog = dogRepository.getById(dogId);
-        supplementsService.getSupplements(dogId);
+
+        symptomQueryRepository.deleteSymptomDogId(dogId);
+        medicalRecordQueryRepository.deleteMedicalRecordsDogId(dogId);
+        weightQueryRepository.deleteWeightByDogId(dogId);
+        excretaQueryRepository.deleteExcretaByDogId(dogId);
+
+        feedQueryRepository.deleteFeedByDogId(dogId);
+        feedRecordQueryRepository.deleteFeedRecordByDogId(dogId);
+
+        //영양제, 영양제 섭취 시간, 영양제 루틴
+        List<Long> supplementsIds = supplementsQueryRepository.getSupplementsIdsByDogId(dogId);
+        supplementsService.deleteSupplementsList(supplementsIds);
+
         dog.softDelete();
     }
 

--- a/meongcare/src/main/java/com/meongcare/domain/dog/application/DogService.java
+++ b/meongcare/src/main/java/com/meongcare/domain/dog/application/DogService.java
@@ -42,16 +42,14 @@ public class DogService {
     private final DogRepository dogRepository;
     private final WeightRepository weightRepository;
     private final ImageHandler imageHandler;
-
-    private SymptomQueryRepository symptomQueryRepository;
-    private FeedQueryRepository feedQueryRepository;
-    private MedicalRecordQueryRepository medicalRecordQueryRepository;
-    private ExcretaQueryRepository excretaQueryRepository;
-    private WeightQueryRepository weightQueryRepository;
-    private FeedRecordQueryRepository feedRecordQueryRepository;
-    private SupplementsQueryRepository supplementsQueryRepository;
-    private SupplementsTimeQueryRepository supplementsTimeQueryRepository;
-    private SupplementsService supplementsService;
+    private final SymptomQueryRepository symptomQueryRepository;
+    private final FeedQueryRepository feedQueryRepository;
+    private final MedicalRecordQueryRepository medicalRecordQueryRepository;
+    private final ExcretaQueryRepository excretaQueryRepository;
+    private final WeightQueryRepository weightQueryRepository;
+    private final FeedRecordQueryRepository feedRecordQueryRepository;
+    private final SupplementsQueryRepository supplementsQueryRepository;
+    private final SupplementsService supplementsService;
 
 
     @Transactional

--- a/meongcare/src/main/java/com/meongcare/domain/excreta/domain/repository/ExcretaQueryRepository.java
+++ b/meongcare/src/main/java/com/meongcare/domain/excreta/domain/repository/ExcretaQueryRepository.java
@@ -55,6 +55,14 @@ public class ExcretaQueryRepository {
                 .execute();
     }
 
+    public void deleteExcretaByDogId(Long dogId) {
+        queryFactory
+                .update(excreta)
+                .set(excreta.deleted, true)
+                .where(dogIdEq(dogId))
+                .execute();
+    }
+
     private BooleanExpression isNotDeleted() {
         return excreta.deleted.isFalse();
     }

--- a/meongcare/src/main/java/com/meongcare/domain/feed/domain/repository/FeedQueryRepository.java
+++ b/meongcare/src/main/java/com/meongcare/domain/feed/domain/repository/FeedQueryRepository.java
@@ -41,6 +41,14 @@ public class FeedQueryRepository {
                 .execute();
     }
 
+    public void deleteFeedByDogId(Long dogId) {
+        queryFactory
+                .update(feed)
+                .set(feed.deleted, true)
+                .where(dogIdEq(dogId))
+                .execute();
+    }
+
     private BooleanExpression isNotDeleted() {
         return feed.deleted.isFalse();
     }

--- a/meongcare/src/main/java/com/meongcare/domain/feed/domain/repository/FeedRecordQueryRepository.java
+++ b/meongcare/src/main/java/com/meongcare/domain/feed/domain/repository/FeedRecordQueryRepository.java
@@ -8,6 +8,7 @@ import com.meongcare.domain.feed.domain.repository.vo.QGetFeedDetailVO;
 import com.meongcare.domain.feed.domain.repository.vo.QGetFeedRecordsPartVO;
 import com.meongcare.domain.feed.domain.repository.vo.QGetFeedRecordsVO;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -167,6 +168,14 @@ public class FeedRecordQueryRepository {
         return queryFactory.selectFrom(feedRecord)
                 .where(feedRecordIdEq(feedRecordId))
                 .fetchFirst();
+    }
+
+    public void deleteFeedRecordByDogId(Long dogId) {
+        queryFactory
+                .update(feedRecord)
+                .set(feedRecord.deleted, true)
+                .where(dogIdEq(dogId))
+                .execute();
     }
 
     private BooleanExpression feedRecordIdEq(Long feedRecordId) {

--- a/meongcare/src/main/java/com/meongcare/domain/medicalrecord/application/MedicalRecordService.java
+++ b/meongcare/src/main/java/com/meongcare/domain/medicalrecord/application/MedicalRecordService.java
@@ -54,7 +54,7 @@ public class MedicalRecordService {
             imageHandler.deleteImage(medicalRecord.getImageUrl());
         }
 
-        medicalRecordQueryRepository.deleteByIds(medicalRecordIds);
+        medicalRecordQueryRepository.deleteMedicalRecords(medicalRecordIds);
     }
 
     public GetMedicalRecordResponse get(Long medicalRecordId) {

--- a/meongcare/src/main/java/com/meongcare/domain/medicalrecord/application/MedicalRecordService.java
+++ b/meongcare/src/main/java/com/meongcare/domain/medicalrecord/application/MedicalRecordService.java
@@ -63,9 +63,9 @@ public class MedicalRecordService {
     }
 
     public GetMedicalRecordsResponse getMedicalRecords(Long dogId, LocalDateTime dateTime) {
-        Dog dog = dogRepository.getDog(dogId);
+
         List<GetMedicalRecordsVo> getMedicalRecordsVos = medicalRecordQueryRepository.getByDate(
-                dog,
+                dogId,
                 LocalDateTimeUtils.createNowMidnight(dateTime),
                 LocalDateTimeUtils.createNextMidnight(dateTime)
         );

--- a/meongcare/src/main/java/com/meongcare/domain/medicalrecord/domain/entity/MedicalRecord.java
+++ b/meongcare/src/main/java/com/meongcare/domain/medicalrecord/domain/entity/MedicalRecord.java
@@ -1,5 +1,6 @@
 package com.meongcare.domain.medicalrecord.domain.entity;
 
+import com.meongcare.common.BaseEntity;
 import com.meongcare.domain.dog.domain.entity.Dog;
 import com.meongcare.domain.medicalrecord.presentation.dto.request.PutMedicalRecordRequest;
 import lombok.AccessLevel;
@@ -14,7 +15,7 @@ import java.time.LocalDateTime;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-public class MedicalRecord {
+public class MedicalRecord extends BaseEntity {
 
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Id

--- a/meongcare/src/main/java/com/meongcare/domain/medicalrecord/domain/repository/MedicalRecordQueryRepository.java
+++ b/meongcare/src/main/java/com/meongcare/domain/medicalrecord/domain/repository/MedicalRecordQueryRepository.java
@@ -1,6 +1,5 @@
 package com.meongcare.domain.medicalrecord.domain.repository;
 
-import com.meongcare.domain.dog.domain.entity.Dog;
 import com.meongcare.domain.medicalrecord.domain.entity.MedicalRecord;
 import com.meongcare.domain.medicalrecord.domain.repository.vo.GetMedicalRecordsVo;
 import com.meongcare.domain.medicalrecord.domain.repository.vo.QGetMedicalRecordsVo;
@@ -54,8 +53,8 @@ public class MedicalRecordQueryRepository {
 
     public void deleteMedicalRecordsDogId(Long dogId) {
         queryFactory
-                .update(feedRecord)
-                .set(feedRecord.deleted, true)
+                .update(medicalRecord)
+                .set(medicalRecord.deleted, true)
                 .where(dogIdEq(dogId))
                 .execute();
     }

--- a/meongcare/src/main/java/com/meongcare/domain/medicalrecord/domain/repository/MedicalRecordQueryRepository.java
+++ b/meongcare/src/main/java/com/meongcare/domain/medicalrecord/domain/repository/MedicalRecordQueryRepository.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Repository;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static com.meongcare.domain.feed.domain.entity.QFeedRecord.feedRecord;
 import static com.meongcare.domain.medicalrecord.domain.entity.QMedicalRecord.*;
 
 @RequiredArgsConstructor
@@ -27,14 +28,15 @@ public class MedicalRecordQueryRepository {
                 .fetch();
     }
 
-    public void deleteByIds(List<Long> medicalRecordIds) {
+    public void deleteMedicalRecords(List<Long> medicalRecordIds) {
         queryFactory
-                .delete(medicalRecord)
+                .update(feedRecord)
+                .set(feedRecord.deleted, true)
                 .where(medicalRecord.id.in(medicalRecordIds))
                 .execute();
     }
 
-    public List<GetMedicalRecordsVo> getByDate(Dog dog, LocalDateTime nowDateTime, LocalDateTime nextDateTime) {
+    public List<GetMedicalRecordsVo> getByDate(Long dogId, LocalDateTime nowDateTime, LocalDateTime nextDateTime) {
         return queryFactory
                 .select(new QGetMedicalRecordsVo(
                         medicalRecord.id,
@@ -42,7 +44,7 @@ public class MedicalRecordQueryRepository {
                 ))
                 .from(medicalRecord)
                 .where(
-                        dogIdEq(dog),
+                        dogIdEq(dogId),
                         dateTimeGoe(nowDateTime),
                         dateTimeLt(nextDateTime)
                 )
@@ -50,8 +52,16 @@ public class MedicalRecordQueryRepository {
                 .fetch();
     }
 
-    private BooleanExpression dogIdEq(Dog dog) {
-        return medicalRecord.dog.eq(dog);
+    public void deleteMedicalRecordsDogId(Long dogId) {
+        queryFactory
+                .update(feedRecord)
+                .set(feedRecord.deleted, true)
+                .where(dogIdEq(dogId))
+                .execute();
+    }
+
+    private BooleanExpression dogIdEq(Long dogId) {
+        return medicalRecord.dog.id.eq(dogId);
     }
     private BooleanExpression dateTimeGoe(LocalDateTime nowDateTime) {
         return medicalRecord.dateTime.goe(nowDateTime);

--- a/meongcare/src/main/java/com/meongcare/domain/member/application/MemberService.java
+++ b/meongcare/src/main/java/com/meongcare/domain/member/application/MemberService.java
@@ -1,6 +1,8 @@
 package com.meongcare.domain.member.application;
 
+import com.meongcare.domain.dog.application.DogService;
 import com.meongcare.domain.dog.domain.DogRepository;
+import com.meongcare.domain.dog.domain.entity.Dog;
 import com.meongcare.domain.member.domain.entity.RevokeMember;
 import com.meongcare.domain.member.domain.entity.Member;
 import com.meongcare.domain.member.domain.repository.MemberRepository;
@@ -14,6 +16,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -26,6 +30,7 @@ public class MemberService {
     private final ImageHandler imageHandler;
     private final RevokeMemberRepository revokeMemberRepository;
     private final DogRepository dogRepository;
+    private final DogService dogService;
 
     public GetProfileResponse getProfile(Long userId) {
         Member member = memberRepository.getUser(userId);
@@ -44,7 +49,11 @@ public class MemberService {
     @Transactional
     public void deleteMember(Long userId) {
         Member member = memberRepository.getUser(userId);
-        dogRepository.deleteByMemberId(member.getId());
+
+        List<Dog> dogs = dogRepository.findAllByMemberAndDeletedFalse(member);
+        for (Dog dog : dogs) {
+            dogService.deleteDog(dog.getId());
+        }
 
         RevokeMember revokeMember = RevokeMember.from(member.getProviderId());
         revokeMemberRepository.save(revokeMember);

--- a/meongcare/src/main/java/com/meongcare/domain/supplements/application/SupplementsService.java
+++ b/meongcare/src/main/java/com/meongcare/domain/supplements/application/SupplementsService.java
@@ -8,12 +8,7 @@ import com.meongcare.domain.notifciation.domain.entity.NotificationType;
 import com.meongcare.domain.supplements.domain.entity.Supplements;
 import com.meongcare.domain.supplements.domain.entity.SupplementsRecord;
 import com.meongcare.domain.supplements.domain.entity.SupplementsTime;
-import com.meongcare.domain.supplements.domain.repository.SupplementsRecordJdbcRepository;
-import com.meongcare.domain.supplements.domain.repository.SupplementsRecordQueryRepository;
-import com.meongcare.domain.supplements.domain.repository.SupplementsRecordRepository;
-import com.meongcare.domain.supplements.domain.repository.SupplementsRepository;
-import com.meongcare.domain.supplements.domain.repository.SupplementsTimeQueryRepository;
-import com.meongcare.domain.supplements.domain.repository.SupplementsTimeRepository;
+import com.meongcare.domain.supplements.domain.repository.*;
 import com.meongcare.domain.supplements.domain.repository.vo.GetAlarmSupplementsVO;
 import com.meongcare.domain.supplements.domain.repository.vo.GetSupplementsAndTimeVO;
 import com.meongcare.domain.supplements.domain.repository.vo.GetSupplementsRoutineVO;
@@ -26,7 +21,6 @@ import com.meongcare.domain.supplements.presentation.dto.response.GetSupplements
 import com.meongcare.domain.supplements.presentation.dto.response.GetSupplementsRoutineResponse;
 import com.meongcare.infra.image.ImageDirectory;
 import com.meongcare.infra.image.ImageHandler;
-import com.meongcare.infra.message.MessageHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
@@ -48,6 +42,7 @@ public class SupplementsService {
     private final SupplementsRepository supplementsRepository;
     private final SupplementsTimeRepository supplementsTimeRepository;
     private final SupplementsTimeQueryRepository supplementsTimeQueryRepository;
+    private final SupplementsQueryRepository supplementsQueryRepository;
     private final SupplementsRecordRepository supplementsRecordRepository;
     private final SupplementsRecordQueryRepository supplementsRecordQueryRepository;
     private final DogRepository dogRepository;
@@ -118,16 +113,19 @@ public class SupplementsService {
     public void deleteSupplements(Long supplementsId) {
         Supplements supplements = supplementsRepository.getSupplement(supplementsId);
         deleteSupplementsTimes(supplementsId);
+        deleteSupplementsRecord(supplementsId);
         supplements.softDelete();
     }
 
     @Transactional
     public void deleteSupplementsList(List<Long> supplementsIds) {
-        for (Long supplementsId : supplementsIds) {
-            Supplements supplements = supplementsRepository.getSupplement(supplementsId);
-            supplements.softDelete();
-            deleteSupplementsTimes(supplementsId);
-        }
+        supplementsQueryRepository.deleteBySupplementsIds(supplementsIds);
+        supplementsTimeQueryRepository.deleteBySupplementsIds(supplementsIds);
+        supplementsRecordQueryRepository.deleteBySupplementsIds(supplementsIds);
+    }
+
+    private void deleteSupplementsRecord(Long supplementsId) {
+        supplementsRecordQueryRepository.deleteBySupplementsId(supplementsId);
     }
 
     private void deleteSupplementsTimes(Long supplementsId) {

--- a/meongcare/src/main/java/com/meongcare/domain/supplements/domain/entity/SupplementsRecord.java
+++ b/meongcare/src/main/java/com/meongcare/domain/supplements/domain/entity/SupplementsRecord.java
@@ -1,5 +1,6 @@
 package com.meongcare.domain.supplements.domain.entity;
 
+import com.meongcare.common.BaseEntity;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,7 +12,7 @@ import java.time.LocalDate;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class SupplementsRecord {
+public class SupplementsRecord extends BaseEntity {
 
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Id

--- a/meongcare/src/main/java/com/meongcare/domain/supplements/domain/repository/SupplementsQueryRepository.java
+++ b/meongcare/src/main/java/com/meongcare/domain/supplements/domain/repository/SupplementsQueryRepository.java
@@ -1,0 +1,34 @@
+package com.meongcare.domain.supplements.domain.repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+
+import java.util.List;
+
+import static com.meongcare.domain.supplements.domain.entity.QSupplements.*;
+
+
+@RequiredArgsConstructor
+@Repository
+public class SupplementsQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+
+    public List<Long> getSupplementsIdsByDogId(Long dogId) {
+        return queryFactory
+                .select(supplements.id)
+                .from(supplements)
+                .where(
+                        dogIdEq(dogId)
+                )
+                .fetch();
+    }
+
+    private BooleanExpression dogIdEq(Long dogId) {
+        return supplements.dog.id.eq(dogId);
+    }
+}

--- a/meongcare/src/main/java/com/meongcare/domain/supplements/domain/repository/SupplementsQueryRepository.java
+++ b/meongcare/src/main/java/com/meongcare/domain/supplements/domain/repository/SupplementsQueryRepository.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 import static com.meongcare.domain.supplements.domain.entity.QSupplements.*;
+import static com.meongcare.domain.supplements.domain.entity.QSupplementsRecord.supplementsRecord;
 
 
 @RequiredArgsConstructor
@@ -30,5 +31,13 @@ public class SupplementsQueryRepository {
 
     private BooleanExpression dogIdEq(Long dogId) {
         return supplements.dog.id.eq(dogId);
+    }
+
+    public void deleteBySupplementsIds(List<Long> supplementsIds) {
+        queryFactory
+                .update(supplements)
+                .set(supplements.deleted, true)
+                .where(supplements.id.in(supplementsIds))
+                .execute();
     }
 }

--- a/meongcare/src/main/java/com/meongcare/domain/supplements/domain/repository/SupplementsRecordQueryRepository.java
+++ b/meongcare/src/main/java/com/meongcare/domain/supplements/domain/repository/SupplementsRecordQueryRepository.java
@@ -1,8 +1,5 @@
 package com.meongcare.domain.supplements.domain.repository;
 
-import com.meongcare.domain.dog.domain.entity.QDog;
-import com.meongcare.domain.member.domain.entity.QMember;
-import com.meongcare.domain.supplements.domain.entity.QSupplements;
 import com.meongcare.domain.supplements.domain.repository.vo.GetAlarmSupplementsVO;
 import com.meongcare.domain.supplements.domain.repository.vo.GetSupplementsRoutineVO;
 import com.meongcare.domain.supplements.domain.repository.vo.QGetAlarmSupplementsVO;

--- a/meongcare/src/main/java/com/meongcare/domain/supplements/domain/repository/SupplementsRecordQueryRepository.java
+++ b/meongcare/src/main/java/com/meongcare/domain/supplements/domain/repository/SupplementsRecordQueryRepository.java
@@ -98,4 +98,19 @@ public class SupplementsRecordQueryRepository {
         return supplementsRecord.supplementsTime.intakeTime.between(time, fiftyNineSecondsLater);
     }
 
+    public void deleteBySupplementsId(Long supplementsId) {
+        queryFactory
+                .update(supplementsRecord)
+                .set(supplementsRecord.deleted, true)
+                .where(supplementsRecord.supplements.id.eq(supplementsId))
+                .execute();
+    }
+
+    public void deleteBySupplementsIds(List<Long> supplementsIds) {
+        queryFactory
+                .update(supplementsRecord)
+                .set(supplementsRecord.deleted, true)
+                .where(supplementsRecord.supplements.id.in(supplementsIds))
+                .execute();
+    }
 }

--- a/meongcare/src/main/java/com/meongcare/domain/supplements/domain/repository/SupplementsTimeQueryRepository.java
+++ b/meongcare/src/main/java/com/meongcare/domain/supplements/domain/repository/SupplementsTimeQueryRepository.java
@@ -46,6 +46,14 @@ public class SupplementsTimeQueryRepository {
                 .fetch();
     }
 
+    public void deleteBySupplementsIds(List<Long> supplementsIds) {
+        queryFactory
+                .update(supplementsTime)
+                .set(supplementsTime.deleted, true)
+                .where(supplementsTime.supplements.id.in(supplementsIds))
+                .execute();
+    }
+
     private BooleanExpression supplementsIdEq(Long supplementsId) {
         return supplementsTime.supplements.id.eq(supplementsId);
     }

--- a/meongcare/src/main/java/com/meongcare/domain/symptom/domain/repository/SymptomQueryRepository.java
+++ b/meongcare/src/main/java/com/meongcare/domain/symptom/domain/repository/SymptomQueryRepository.java
@@ -44,6 +44,14 @@ public class SymptomQueryRepository {
                 .execute();
     }
 
+    public void deleteSymptomDogId(Long dogId) {
+        queryFactory
+                .update(symptom)
+                .set(symptom.deleted, true)
+                .where(symptom.dog.id.eq(dogId))
+                .execute();
+    }
+
     private BooleanExpression isNotDeleted() {
         return symptom.deleted.isFalse();
     }

--- a/meongcare/src/main/java/com/meongcare/domain/weight/domain/repository/WeightQueryRepository.java
+++ b/meongcare/src/main/java/com/meongcare/domain/weight/domain/repository/WeightQueryRepository.java
@@ -16,6 +16,7 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
+import static com.meongcare.domain.feed.domain.entity.QFeedRecord.feedRecord;
 import static com.meongcare.domain.weight.domain.entity.QWeight.weight;
 
 @RequiredArgsConstructor
@@ -105,6 +106,14 @@ public class WeightQueryRepository {
                 )
                 .fetchFirst();
         return fetchWeight != null;
+    }
+
+    public void deleteWeightByDogId(Long dogId) {
+        queryFactory
+                .update(weight)
+                .set(weight.deleted, true)
+                .where(dogIdEq(dogId))
+                .execute();
     }
 
     private BooleanExpression dateEq(LocalDate date) {

--- a/meongcare/src/main/java/com/meongcare/domain/weight/domain/repository/WeightQueryRepository.java
+++ b/meongcare/src/main/java/com/meongcare/domain/weight/domain/repository/WeightQueryRepository.java
@@ -16,7 +16,6 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
-import static com.meongcare.domain.feed.domain.entity.QFeedRecord.feedRecord;
 import static com.meongcare.domain.weight.domain.entity.QWeight.weight;
 
 @RequiredArgsConstructor


### PR DESCRIPTION
### ✅ 작업한 내용
- 강아지 삭제를 하면 관련 엔티티 soft delete
- 영양제 삭제 시 영양제 루틴도 soft delete
- 회원 탈퇴 시 강아지 정보(+관련 데이터) soft delete


### ✅ 관련 이슈
- Resolved: #100 
