### PR TITLE
사료 기록 하나 남은거 삭제 시, 사료 삭제 처리 및 ID 기반 조회 조건 추가

### DIFF
--- a/meongcare/src/main/java/com/meongcare/domain/excreta/domain/repository/ExcretaRepository.java
+++ b/meongcare/src/main/java/com/meongcare/domain/excreta/domain/repository/ExcretaRepository.java
@@ -5,10 +5,14 @@ import com.meongcare.common.error.exception.clientError.EntityNotFoundException;
 import com.meongcare.domain.excreta.domain.entity.Excreta;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ExcretaRepository extends JpaRepository<Excreta, Long> {
 
     default Excreta getById(Long id) {
-        return this.findById(id)
+        return this.findByIdAndDeletedFalse(id)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.EXCRETA_ENTITY_NOT_FOUND));
     }
+
+    Optional<Excreta> findByIdAndDeletedFalse(Long id);
 }

--- a/meongcare/src/main/java/com/meongcare/domain/feed/application/FeedService.java
+++ b/meongcare/src/main/java/com/meongcare/domain/feed/application/FeedService.java
@@ -49,6 +49,7 @@ public class FeedService {
     private final ApplicationEventPublisher eventPublisher;
 
     private static final Integer DEFAULT_RECOMMEND_INTAKE = 0;
+    private static final Integer REST_FEED_RECORD = 1;
 
     @Transactional
     public void saveFeed(SaveFeedRequest request, MultipartFile multipartFile) {
@@ -139,6 +140,12 @@ public class FeedService {
 
     @Transactional
     public void deleteFeedRecord(Long feedRecordId) {
+        FeedRecord feedRecord = feedRecordRepository.getById(feedRecordId);
+        Feed feed = feedRecord.getFeed();
+        int feedRecordCount = feedRecordQueryRepository.getFeedRecordCountByFeedId(feed.getId());
+        if (feedRecordCount == REST_FEED_RECORD) {
+            feedQueryRepository.deleteFeed(feed.getId());
+        }
         feedRecordQueryRepository.deleteFeedRecord(feedRecordId);
     }
 

--- a/meongcare/src/main/java/com/meongcare/domain/feed/domain/repository/FeedRecordQueryRepository.java
+++ b/meongcare/src/main/java/com/meongcare/domain/feed/domain/repository/FeedRecordQueryRepository.java
@@ -178,6 +178,14 @@ public class FeedRecordQueryRepository {
                 .execute();
     }
 
+    public int getFeedRecordCountByFeedId(Long feedRecordId) {
+        return queryFactory
+                .selectFrom(feedRecord)
+                .where(feedRecordIdEq(feedRecordId))
+                .fetch()
+                .size();
+    }
+
     private BooleanExpression feedRecordIdEq(Long feedRecordId) {
         return feedRecord.id.eq(feedRecordId);
     }

--- a/meongcare/src/main/java/com/meongcare/domain/feed/domain/repository/FeedRecordRepository.java
+++ b/meongcare/src/main/java/com/meongcare/domain/feed/domain/repository/FeedRecordRepository.java
@@ -5,9 +5,13 @@ import com.meongcare.common.error.exception.clientError.EntityNotFoundException;
 import com.meongcare.domain.feed.domain.entity.FeedRecord;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface FeedRecordRepository extends JpaRepository<FeedRecord, Long> {
     default FeedRecord getById(Long id) {
-        return this.findById(id)
+        return this.findByIdAndDeletedFalse(id)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.FEED_RECORD_ENTITY_NOT_FOUND));
     }
+
+    Optional<FeedRecord> findByIdAndDeletedFalse(Long id);
 }

--- a/meongcare/src/main/java/com/meongcare/domain/feed/domain/repository/FeedRepository.java
+++ b/meongcare/src/main/java/com/meongcare/domain/feed/domain/repository/FeedRepository.java
@@ -5,10 +5,14 @@ import com.meongcare.common.error.exception.clientError.EntityNotFoundException;
 import com.meongcare.domain.feed.domain.entity.Feed;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface FeedRepository extends JpaRepository<Feed, Long> {
 
     default Feed getById(Long id) {
-        return this.findById(id)
+        return this.findByIdAndDeletedFalse(id)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.FEED_ENTITY_NOT_FOUND));
     }
+
+    Optional<Feed> findByIdAndDeletedFalse(Long id);
 }

--- a/meongcare/src/main/java/com/meongcare/domain/symptom/domain/repository/SymptomRepository.java
+++ b/meongcare/src/main/java/com/meongcare/domain/symptom/domain/repository/SymptomRepository.java
@@ -5,10 +5,14 @@ import com.meongcare.common.error.exception.clientError.EntityNotFoundException;
 import com.meongcare.domain.symptom.domain.entity.Symptom;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface SymptomRepository extends JpaRepository<Symptom, Long> {
 
     default Symptom getById(Long id) {
-        return this.findById(id)
+        return this.findByIdAndDeletedFalse(id)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.SYMPTOM_ENTITY_NOT_FOUND));
     }
+
+    Optional<Symptom> findByIdAndDeletedFalse(Long id);
 }


### PR DESCRIPTION
### ✅ 작업한 내용
-  사료 기록 하나 남은거 삭제 시, 사료 삭제 처리
id 조회 시 삭제된 데이터 조회하지 않도록 조건문 추가


### ✅ 관련 이슈
- Resolved: #103 , #131 
