### PR TITLE
[FIX] fcm 로그인 시 삭제 #147

### DIFF
--- a/meongcare/src/main/java/com/meongcare/common/jwt/JwtAuthenticationFilter.java
+++ b/meongcare/src/main/java/com/meongcare/common/jwt/JwtAuthenticationFilter.java
@@ -28,8 +28,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         try {
             String accessToken = request.getHeader(ACCESS_TOKEN_HEADER);
-            Long userId = jwtService.parseJwtToken(accessToken);
-            memberRepository.getUser(userId);
+            Long memberId = jwtService.parseJwtToken(accessToken);
+            memberRepository.getMember(memberId);
             filterChain.doFilter(request, response);
         } catch (Exception e) {
             e.printStackTrace();

--- a/meongcare/src/main/java/com/meongcare/common/jwt/JwtValidateArgumentResolver.java
+++ b/meongcare/src/main/java/com/meongcare/common/jwt/JwtValidateArgumentResolver.java
@@ -35,7 +35,7 @@ public class JwtValidateArgumentResolver implements HandlerMethodArgumentResolve
             throw new InvalidTokenException(ErrorCode.INVALID_ACCESS_TOKEN);
         }
 
-        Long userIdx = jwtService.parseJwtToken(accessToken);
-        return userIdx;
+        Long memberId = jwtService.parseJwtToken(accessToken);
+        return memberId;
     }
 }

--- a/meongcare/src/main/java/com/meongcare/domain/auth/application/AuthService.java
+++ b/meongcare/src/main/java/com/meongcare/domain/auth/application/AuthService.java
@@ -88,8 +88,8 @@ public class AuthService {
 
     @Transactional
     public void logout(String refreshToken) {
-        Long userId = jwtService.parseJwtToken(refreshToken);
-        Member member = memberRepository.getUser(userId);
+        Long memberId = jwtService.parseJwtToken(refreshToken);
+        Member member = memberRepository.getMember(memberId);
         member.deleteFcmToken();
         refreshTokenRedisRepository.deleteById(refreshToken);
     }

--- a/meongcare/src/main/java/com/meongcare/domain/auth/application/AuthService.java
+++ b/meongcare/src/main/java/com/meongcare/domain/auth/application/AuthService.java
@@ -76,7 +76,6 @@ public class AuthService {
 
     public ReissueResponse reissue(String refreshToken) {
         Long userId = jwtService.parseJwtToken(refreshToken);
-
         refreshTokenRedisRepository
                 .findById(refreshToken)
                 .orElseThrow(() -> new InvalidTokenException(ErrorCode.INVALID_REFRESH_TOKEN));
@@ -87,8 +86,11 @@ public class AuthService {
         return reissueResponse;
     }
 
+    @Transactional
     public void logout(String refreshToken) {
+        Long userId = jwtService.parseJwtToken(refreshToken);
+        Member member = memberRepository.getUser(userId);
+        member.deleteFcmToken();
         refreshTokenRedisRepository.deleteById(refreshToken);
     }
-
 }

--- a/meongcare/src/main/java/com/meongcare/domain/auth/presentation/controller/AuthController.java
+++ b/meongcare/src/main/java/com/meongcare/domain/auth/presentation/controller/AuthController.java
@@ -34,7 +34,7 @@ public class AuthController {
         return ResponseEntity.ok().body(reissueResponse);
     }
 
-    @Operation(description = "로그아웃 (엑세스 토큰 삭제)")
+    @Operation(description = "로그아웃 (리프레시 토큰 삭제)")
     @DeleteMapping("/logout")
     public ResponseEntity<Void> login(@RequestHeader("RefreshToken") String refreshToken) {
         authService.logout(refreshToken);

--- a/meongcare/src/main/java/com/meongcare/domain/dog/application/DogService.java
+++ b/meongcare/src/main/java/com/meongcare/domain/dog/application/DogService.java
@@ -53,8 +53,8 @@ public class DogService {
 
 
     @Transactional
-    public void saveDog(MultipartFile multipartFile, SaveDogRequest saveDogRequest, Long userId) {
-        Member member = memberRepository.getUser(userId);
+    public void saveDog(MultipartFile multipartFile, SaveDogRequest saveDogRequest, Long memberId) {
+        Member member = memberRepository.getMember(memberId);
         String dogImageURL = imageHandler.uploadImage(multipartFile, ImageDirectory.DOG);
 
         Dog dog = saveDogRequest.toEntity(member, dogImageURL);
@@ -64,8 +64,8 @@ public class DogService {
         weightRepository.save(weight);
     }
 
-    public GetDogsResponse getDogs(Long userId) {
-        Member member = memberRepository.getUser(userId);
+    public GetDogsResponse getDogs(Long memberId) {
+        Member member = memberRepository.getMember(memberId);
         List<Dog> dogs = dogRepository.findAllByMemberAndDeletedFalse(member);
         return GetDogsResponse.of(dogs);
     }

--- a/meongcare/src/main/java/com/meongcare/domain/dog/presentation/controller/DogController.java
+++ b/meongcare/src/main/java/com/meongcare/domain/dog/presentation/controller/DogController.java
@@ -32,16 +32,16 @@ public class DogController {
     public ResponseEntity<Void> saveDog(
             @RequestPart(value = "file") MultipartFile multipartFile,
             @Valid @RequestPart(value = "dto") SaveDogRequest saveDogRequest,
-            @JwtValidation Long userId) {
-        dogService.saveDog(multipartFile, saveDogRequest, userId);
+            @JwtValidation Long memberId) {
+        dogService.saveDog(multipartFile, saveDogRequest, memberId);
         return ResponseEntity.ok().build();
     }
 
     @Operation(description = "반려동물 목록")
     @Parameter(name = "AccessToken", in = ParameterIn.HEADER, required = true)
     @GetMapping
-    public ResponseEntity<GetDogsResponse> getDogs(@JwtValidation Long userId) {
-        GetDogsResponse getDogsResponse = dogService.getDogs(userId);
+    public ResponseEntity<GetDogsResponse> getDogs(@JwtValidation Long memberId) {
+        GetDogsResponse getDogsResponse = dogService.getDogs(memberId);
         return ResponseEntity.ok().body(getDogsResponse);
     }
 

--- a/meongcare/src/main/java/com/meongcare/domain/member/application/MemberService.java
+++ b/meongcare/src/main/java/com/meongcare/domain/member/application/MemberService.java
@@ -32,8 +32,8 @@ public class MemberService {
     private final DogRepository dogRepository;
     private final DogService dogService;
 
-    public GetProfileResponse getProfile(Long userId) {
-        Member member = memberRepository.getUser(userId);
+    public GetProfileResponse getProfile(Long memberId) {
+        Member member = memberRepository.getMember(memberId);
         return GetProfileResponse.of(
                 member.getEmail(),
                 member.getProfileImageUrl(),
@@ -41,14 +41,14 @@ public class MemberService {
     }
 
     @Transactional
-    public void updateAlarm(Long userId, boolean pushAgreement) {
-        Member member = memberRepository.getUser(userId);
+    public void updateAlarm(Long memberId, boolean pushAgreement) {
+        Member member = memberRepository.getMember(memberId);
         member.updatePushAgreement(pushAgreement);
     }
 
     @Transactional
-    public void deleteMember(Long userId) {
-        Member member = memberRepository.getUser(userId);
+    public void deleteMember(Long memberId) {
+        Member member = memberRepository.getMember(memberId);
 
         List<Dog> dogs = dogRepository.findAllByMemberAndDeletedFalse(member);
         for (Dog dog : dogs) {
@@ -61,8 +61,8 @@ public class MemberService {
     }
 
     @Transactional
-    public void updateProfileImage(Long userId, MultipartFile multipartFile) {
-        Member member = memberRepository.getUser(userId);
+    public void updateProfileImage(Long memberId, MultipartFile multipartFile) {
+        Member member = memberRepository.getMember(memberId);
         String bucketName = imageHandler.getBucketNameFromUrl(member.getProfileImageUrl());
         if (bucketName.startsWith(bucket)) {
             imageHandler.deleteImage(member.getProfileImageUrl());

--- a/meongcare/src/main/java/com/meongcare/domain/member/domain/entity/Member.java
+++ b/meongcare/src/main/java/com/meongcare/domain/member/domain/entity/Member.java
@@ -72,4 +72,8 @@ public class Member extends BaseEntity {
     public void updateFcmToken(String fcmToken) {
         this.fcmToken = fcmToken;
     }
+
+    public void deleteFcmToken() {
+        this.fcmToken = null;
+    }
 }

--- a/meongcare/src/main/java/com/meongcare/domain/member/domain/repository/MemberRepository.java
+++ b/meongcare/src/main/java/com/meongcare/domain/member/domain/repository/MemberRepository.java
@@ -12,7 +12,7 @@ import java.util.Optional;
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByProviderId(String providerId);
 
-    default Member getUser(Long id) {
+    default Member getMember(Long id) {
         return this.findByIdAndDeleted(id, false)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.MEMBER_NOT_FOUND));
     }

--- a/meongcare/src/main/java/com/meongcare/domain/member/presentation/controller/MemberController.java
+++ b/meongcare/src/main/java/com/meongcare/domain/member/presentation/controller/MemberController.java
@@ -26,34 +26,34 @@ public class MemberController {
     @Operation(description = "나의 정보 조회")
     @Parameter(name = "AccessToken", in = ParameterIn.HEADER, required = true)
     @GetMapping("/profile")
-    public ResponseEntity<GetProfileResponse> getProfile(@JwtValidation Long userId){
-        GetProfileResponse getProfileResponse = memberService.getProfile(userId);
+    public ResponseEntity<GetProfileResponse> getProfile(@JwtValidation Long memberId){
+        GetProfileResponse getProfileResponse = memberService.getProfile(memberId);
         return ResponseEntity.ok().body(getProfileResponse);
     }
 
     @Operation(description = "프로필 사진 수정")
     @Parameter(name = "AccessToken", in = ParameterIn.HEADER, required = true)
     @PatchMapping("/profile")
-    public ResponseEntity<Void> updateProfileImage(@JwtValidation Long userId,
+    public ResponseEntity<Void> updateProfileImage(@JwtValidation Long memberId,
                                            @RequestPart(value = "file") MultipartFile multipartFile){
-        memberService.updateProfileImage(userId, multipartFile);
+        memberService.updateProfileImage(memberId, multipartFile);
         return ResponseEntity.ok().build();
     }
 
     @Operation(description = "알림 설정")
     @Parameter(name = "AccessToken", in = ParameterIn.HEADER, required = true)
     @PatchMapping("/alarm")
-    public ResponseEntity<Void> updateAlarm(@JwtValidation Long userId,
+    public ResponseEntity<Void> updateAlarm(@JwtValidation Long memberId,
                                      @RequestParam("pushAgreement") boolean pushAgreement) {
-        memberService.updateAlarm(userId, pushAgreement);
+        memberService.updateAlarm(memberId, pushAgreement);
         return ResponseEntity.ok().build();
     }
 
     @Operation(description = "회원 탈퇴")
     @Parameter(name = "AccessToken", in = ParameterIn.HEADER, required = true)
     @DeleteMapping
-    public ResponseEntity<Void> deleteMember(@JwtValidation Long userId){
-        memberService.deleteMember(userId);
+    public ResponseEntity<Void> deleteMember(@JwtValidation Long memberId){
+        memberService.deleteMember(memberId);
         return ResponseEntity.ok().build();
     }
 }

--- a/meongcare/src/main/java/com/meongcare/domain/notifciation/application/NotificationService.java
+++ b/meongcare/src/main/java/com/meongcare/domain/notifciation/application/NotificationService.java
@@ -30,17 +30,17 @@ public class NotificationService {
             return;
         }
         List<Long> memberIds = notificationRecords.stream()
-                .map(NotificationRecord::getUserId)
+                .map(NotificationRecord::getMemberId)
                 .collect(Collectors.toList());
 
         Map<Long, String> memberIdFcmTokenMap = memberRepository.findAllById(memberIds).stream()
                 .collect(Collectors.toMap(Member::getId, Member::getFcmToken));
 
         for (NotificationRecord notificationRecord : notificationRecords) {
-            String fcmToken = memberIdFcmTokenMap.get(notificationRecord.getUserId());
+            String fcmToken = memberIdFcmTokenMap.get(notificationRecord.getMemberId());
             eventPublisher.publishEvent(FcmNotificationDTO.of(
                     notificationRecord.getTitle(), notificationRecord.getBody(), fcmToken,
-                    notificationRecord.getNotificationType(), notificationRecord.getUserId(), notificationRecord.getDogId()
+                    notificationRecord.getNotificationType(), notificationRecord.getMemberId(), notificationRecord.getDogId()
             ));
         }
 

--- a/meongcare/src/main/java/com/meongcare/domain/notifciation/domain/entity/NotificationRecord.java
+++ b/meongcare/src/main/java/com/meongcare/domain/notifciation/domain/entity/NotificationRecord.java
@@ -25,7 +25,7 @@ public class NotificationRecord extends BaseEntity {
     @Enumerated(value = EnumType.STRING)
     private NotificationType notificationType;
 
-    private Long userId;
+    private Long memberId;
 
     private Long dogId;
 
@@ -34,9 +34,9 @@ public class NotificationRecord extends BaseEntity {
     private String body;
 
     @Builder
-    public NotificationRecord(NotificationType notificationType, Long userId, Long dogId, String title, String body) {
+    public NotificationRecord(NotificationType notificationType, Long memberId, Long dogId, String title, String body) {
         this.notificationType = notificationType;
-        this.userId = userId;
+        this.memberId = memberId;
         this.dogId = dogId;
         this.title = title;
         this.body = body;

--- a/meongcare/src/main/java/com/meongcare/infra/message/firebase/MessageHandlerFirebase.java
+++ b/meongcare/src/main/java/com/meongcare/infra/message/firebase/MessageHandlerFirebase.java
@@ -4,6 +4,8 @@ import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.Notification;
+import com.meongcare.domain.member.domain.entity.Member;
+import com.meongcare.domain.member.domain.repository.MemberRepository;
 import com.meongcare.domain.notifciation.domain.entity.NotificationRecord;
 import com.meongcare.domain.notifciation.domain.entity.NotificationType;
 import com.meongcare.domain.notifciation.domain.repository.NotificationRecordRepository;
@@ -21,22 +23,25 @@ public class MessageHandlerFirebase implements MessageHandler {
 
     private final FirebaseMessaging firebaseMessaging;
     private final NotificationRecordRepository notificationRecordRepository;
+    private final MemberRepository memberRepository;
 
     @Transactional(propagation = Propagation.REQUIRES_NEW, noRollbackFor = FirebaseMessagingException.class)
     @Override
     public void sendMessage(String title, String body, String fcmToken,
                             NotificationType notificationType, Long memberId, Long dogId
     ) {
+        if (fcmToken == null) {
+            return;
+        }
+
         Notification notification = createNotification(title, body);
         Message message = createMessage(fcmToken, notification);
 
         try {
             firebaseMessaging.send(message);
         } catch (FirebaseMessagingException e) {
-            notificationRecordRepository.save(new NotificationRecord(
-                    notificationType, memberId, dogId,
-                    title, body
-            ));
+            Member member = memberRepository.getMember(memberId);
+            member.deleteFcmToken();
             log.error("알림 보내기를 실패했습니다 errorMessage = {}", e.getMessage());
         }
     }

--- a/meongcare/src/main/java/com/meongcare/infra/message/firebase/MessageHandlerFirebase.java
+++ b/meongcare/src/main/java/com/meongcare/infra/message/firebase/MessageHandlerFirebase.java
@@ -40,9 +40,15 @@ public class MessageHandlerFirebase implements MessageHandler {
         try {
             firebaseMessaging.send(message);
         } catch (FirebaseMessagingException e) {
+            log.error("알림 보내기를 실패했습니다 errorMessage = {}", e.getMessage());
             Member member = memberRepository.getMember(memberId);
             member.deleteFcmToken();
+        } catch (Exception e) {
             log.error("알림 보내기를 실패했습니다 errorMessage = {}", e.getMessage());
+            notificationRecordRepository.save(new NotificationRecord(
+                    notificationType, memberId, dogId,
+                    title, body
+            ));
         }
     }
 


### PR DESCRIPTION
### ✅ 작업한 내용
- 알림 전송이 실패했던 이유는 fcm이 변경된 경우, 원래의 fcm으로 알림 전송을 하려고 해서였던 것 같습니다!
 -> 로그아웃 시 fcm을 삭제하고 fcm이 없는 사용자에겐 알림이 가지 않게 함.
- 근영님이 알림 실패 시 notification_record을 생성하게 만들어주셨는데요, FirebaseMessagingException가 발생하는 경우는 토큰 형식이 이상하거나 토큰이 fcm 서버에 없는 등 결국 토큰의 문제라 NotificationScheduler도 제대로 동작하지 않게 됩니다. 그래서  FirebaseMessagingException이 발생하면 유저 fcm을 삭제하게 했습니다..! 

- member, user 이름이 혼동되어서 member로 통일했습니다. notification_record 테이블 칼럼명을 변경해야 하는데 머지 전에 수정하겠습니다.


### ✅ 관련 이슈
- Resolved: #147 
